### PR TITLE
Update setting.py for Django version 3.2

### DIFF
--- a/dj4e-samples/settings.py
+++ b/dj4e-samples/settings.py
@@ -226,4 +226,9 @@ if (len(sys.argv) >= 2 and sys.argv[1] == 'runserver'):
             },
         }
     }
+    
+    # DEFAULT_AUTO_FIELD New in Django 3.2 
+    # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
+    
+    DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 '''


### PR DESCRIPTION
Default primary key field type to use for models that don’t have a field with primary_key=True.
DEFAULT_AUTO_FIELD: 'django.db.models.AutoField' . New in Django 3.2